### PR TITLE
use `actions/checkout@v3`

### DIFF
--- a/.github/workflows/publish-to-redaxo.yml
+++ b/.github/workflows/publish-to-redaxo.yml
@@ -9,7 +9,7 @@ jobs:
   redaxo_publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: FriendsOfREDAXO/installer-action@v1
       with:
         myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/